### PR TITLE
Update Privacy_Public Access to Court Records State Links.csv

### DIFF
--- a/Privacy_Public Access to Court Records State Links.csv
+++ b/Privacy_Public Access to Court Records State Links.csv
@@ -91,6 +91,7 @@ Florida,Supreme Court Online Docket,http://jweb.flcourts.org/pls/docket/ds_docke
 ,Ventura Superior,http://www.ventura.courts.ca.gov/case-inquiry.html
 Georgia,Cobb County (Superior),https://www.cobbsuperiorcourtclerk.com/courts/
 ,"Gwinnett County (Superior, State, and Magistrate Courts)",http://www.gwinnettcourts.com/
+,"Fulton County Superior, State, and Magistrate Courts)",https://publicrecordsaccess.fultoncountyga.gov/Portal/Home/Dashboard/29
 Hawaii,eCourt Kokua,http://www.courts.state.hi.us/legal_references/records/jims_system_availability.html
 ,Ho`ohiki,http://www.courts.state.hi.us/legal_references/records/hoohiki_disclaimer.html
 Idaho,Idaho iCourt Portal,https://mycourts.idaho.gov/


### PR DESCRIPTION
Adds Fulton County, Georgia courts. Most of Atlanta is in Fulton County.  